### PR TITLE
Add mach-o file format

### DIFF
--- a/source/fileformat/mach-o.c
+++ b/source/fileformat/mach-o.c
@@ -4,7 +4,7 @@ void parseMach32(FILE* fp, long fileSize)
 {
     int segCounter = 0, sectCounter = 0, fileIndex = 0;
 
-    struct mach_header machHeader = { 0 };
+    mach_header machHeader = { 0 };
 
     uint8_t* buffer = malloc(sizeof(mach_header));
     fread(buffer, sizeof(uint8_t), sizeof(mach_header), fp);
@@ -21,7 +21,7 @@ void parseMach32(FILE* fp, long fileSize)
 
     // TODO: Review. 4?
     for (segCounter = 0; segCounter < 4; segCounter++) {
-        struct segment_command segmentCmd = { 0 };
+        segment_command segmentCmd = { 0 };
 
         buffer = malloc(sizeof(segment_command));
         fseek(fp, fileIndex, SEEK_SET);
@@ -82,6 +82,86 @@ void parseMach32(FILE* fp, long fileSize)
     }
 }
 
-void parseMach64(FILE* fp, long fileSize) {
+void parseMach64(FILE* fp, long fileSize)
+{
+    int segCounter = 0, sectCounter = 0, fileIndex = 0;
 
+    mach_header_64 machHeader = { 0 };
+
+    uint8_t* buffer = malloc(sizeof(mach_header_64));
+    fread(buffer, sizeof(uint8_t), sizeof(mach_header_64), fp);
+    machHeader.magic      = *(uint32_t*)&buffer[0x00];
+    machHeader.cputype    = *(uint32_t*)&buffer[0x04];
+    machHeader.cpusubtype = *(uint32_t*)&buffer[0x08];
+    machHeader.filetype   = *(uint32_t*)&buffer[0x0C];
+    machHeader.ncmds      = *(uint32_t*)&buffer[0x10];
+    machHeader.sizeofcmds = *(uint32_t*)&buffer[0x14];
+    machHeader.flags      = *(uint32_t*)&buffer[0x18];
+    machHeader.reserved   = *(uint32_t*)&buffer[0x1C];
+    free(buffer);
+    printMachHeader64(machHeader);
+    fileIndex += sizeof(mach_header_64);
+
+    // TODO: Review. 4?
+    for (segCounter = 0; segCounter < 4; segCounter++) {
+        segment_command_64 segmentCmd = { 0 };
+
+        buffer = malloc(sizeof(segment_command_64));
+        fseek(fp, fileIndex, SEEK_SET);
+        fread(buffer, sizeof(uint8_t), sizeof(segment_command_64), fp);
+        segmentCmd.cmd        = *(uint32_t*)&buffer[0x00];
+        segmentCmd.cmdsize    = *(uint32_t*)&buffer[0x04];
+        strcpy(segmentCmd.segname, (char*)&buffer[0x08]);
+        segmentCmd.vmaddr     = *(uint32_t*)&buffer[0x18];
+        segmentCmd.vmsize     = *(uint32_t*)&buffer[0x20];
+        segmentCmd.fileoff    = *(uint32_t*)&buffer[0x28];
+        segmentCmd.filesize   = *(uint32_t*)&buffer[0x30];
+        segmentCmd.maxprot    = *(uint32_t*)&buffer[0x38];
+        segmentCmd.initprot   = *(uint32_t*)&buffer[0x3C];
+        segmentCmd.nsects     = *(uint32_t*)&buffer[0x40];
+        segmentCmd.flags      = *(uint32_t*)&buffer[0x44];
+        free(buffer);
+
+        printf("\n");
+        printSegmentCommand64(segmentCmd);
+
+        for (sectCounter = 0; sectCounter < segmentCmd.nsects; sectCounter++) {
+            section_64 sect = { 0 };
+
+            buffer = malloc(sizeof(section_64));
+            int seek = fileIndex + sizeof(segment_command_64)
+                       + sectCounter * sizeof(section_64);
+            fseek(fp, seek, SEEK_SET);
+            fread(buffer, sizeof(uint8_t), sizeof(section_64), fp);
+            strcpy(sect.sectname, (char*)&buffer[0x00]);
+            strcpy(sect.segname, (char*)&buffer[0x10]);
+            sect.addr       = *(uint32_t*)&buffer[0x20];
+            sect.size       = *(uint32_t*)&buffer[0x28];
+            sect.offset     = *(uint32_t*)&buffer[0x30];
+            sect.align      = *(uint32_t*)&buffer[0x34];
+            sect.reloff     = *(uint32_t*)&buffer[0x38];
+            sect.nreloc     = *(uint32_t*)&buffer[0x3C];
+            sect.flags      = *(uint32_t*)&buffer[0x40];
+            sect.reserved1  = *(uint32_t*)&buffer[0x44];
+            sect.reserved2  = *(uint32_t*)&buffer[0x48];
+            free(buffer);
+
+            printf("\n");
+            printSection64(sect);
+
+            // Print disassembly
+            // TODO: At the time of writing this, I do not have a
+            // x86_64 disassembler.
+            // uint8_t* codeSection = malloc(sect.size);
+            // fseek(fp, sect.offset, SEEK_SET); // TODO: Error checking
+            // fread(codeSection, sizeof(uint8_t), sect.size, fp);
+            // disassemble_x86(
+            //     sect.sectname,
+            //     sect.addr,
+            //     codeSection,
+            //     sect.size);
+            // free(codeSection);
+        }
+        fileIndex += segmentCmd.cmdsize;
+    }
 }

--- a/source/fileformat/mach-o.c
+++ b/source/fileformat/mach-o.c
@@ -1,0 +1,87 @@
+#include "mach-o.h"
+
+void parseMach32(FILE* fp, long fileSize)
+{
+    int segCounter = 0, sectCounter = 0, fileIndex = 0;
+
+    struct mach_header machHeader = { 0 };
+
+    uint8_t* buffer = malloc(sizeof(mach_header));
+    fread(buffer, sizeof(uint8_t), sizeof(mach_header), fp);
+    machHeader.magic      = *(uint32_t*)&buffer[0x00];
+    machHeader.cputype    = *(uint32_t*)&buffer[0x04];
+    machHeader.cpusubtype = *(uint32_t*)&buffer[0x08];
+    machHeader.filetype   = *(uint32_t*)&buffer[0x0C];
+    machHeader.ncmds      = *(uint32_t*)&buffer[0x10];
+    machHeader.sizeofcmds = *(uint32_t*)&buffer[0x14];
+    machHeader.flags      = *(uint32_t*)&buffer[0x18];
+    free(buffer);
+    printMachHeader(machHeader);
+    fileIndex += sizeof(mach_header);
+
+    // TODO: Review. 4?
+    for (segCounter = 0; segCounter < 4; segCounter++) {
+        struct segment_command segmentCmd = { 0 };
+
+        buffer = malloc(sizeof(segment_command));
+        fseek(fp, fileIndex, SEEK_SET);
+        fread(buffer, sizeof(uint8_t), sizeof(segment_command), fp);
+        segmentCmd.cmd        = *(uint32_t*)&buffer[0x00];
+        segmentCmd.cmdsize    = *(uint32_t*)&buffer[0x04];
+        strcpy(segmentCmd.segname, (char*)&buffer[0x08]);
+        segmentCmd.vmaddr     = *(uint32_t*)&buffer[0x18];
+        segmentCmd.vmsize     = *(uint32_t*)&buffer[0x1C];
+        segmentCmd.fileoff    = *(uint32_t*)&buffer[0x20];
+        segmentCmd.filesize   = *(uint32_t*)&buffer[0x24];
+        segmentCmd.maxprot    = *(uint32_t*)&buffer[0x28];
+        segmentCmd.initprot   = *(uint32_t*)&buffer[0x2C];
+        segmentCmd.nsects     = *(uint32_t*)&buffer[0x30];
+        segmentCmd.flags      = *(uint32_t*)&buffer[0x34];
+        free(buffer);
+
+        printf("\n");
+        printSegmentCommand(segmentCmd);
+
+        for (sectCounter = 0; sectCounter < segmentCmd.nsects; sectCounter++) {
+            section sect = { 0 };
+
+            buffer = malloc(sizeof(section));
+            int seek = fileIndex + sizeof(segment_command)
+                       + sectCounter * sizeof(section);
+            fseek(fp, seek, SEEK_SET);
+            fread(buffer, sizeof(uint8_t), sizeof(section), fp);
+            strcpy(sect.sectname, (char*)&buffer[0x00]);
+            strcpy(sect.segname, (char*)&buffer[0x10]);
+            sect.addr       = *(uint32_t*)&buffer[0x20];
+            sect.size       = *(uint32_t*)&buffer[0x24];
+            sect.offset     = *(uint32_t*)&buffer[0x28];
+            sect.align      = *(uint32_t*)&buffer[0x2C];
+            sect.reloff     = *(uint32_t*)&buffer[0x30];
+            sect.nreloc     = *(uint32_t*)&buffer[0x34];
+            sect.flags      = *(uint32_t*)&buffer[0x38];
+            sect.reserved1  = *(uint32_t*)&buffer[0x3C];
+            sect.reserved2  = *(uint32_t*)&buffer[0x40];
+            free(buffer);
+
+            printf("\n");
+            printSection(sect);
+
+            // Print disassembly
+            uint8_t* codeSection = malloc(sect.size);
+            fseek(fp, sect.offset, SEEK_SET); // TODO: Error checking
+            fread(codeSection, sizeof(uint8_t), sect.size, fp);
+            disassemble_x86(
+                sect.sectname,
+                sect.addr,
+                codeSection,
+                sect.size);
+            free(codeSection);
+        }
+
+        fileIndex += segmentCmd.cmdsize;
+    }
+}
+
+void parseMach64(FILE* fp, long fileSize) {
+
+}

--- a/source/fileformat/mach-o.h
+++ b/source/fileformat/mach-o.h
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "mach-ostructs.h"
+#include "../disassembler/x86.h"
+
+void parseMach32(FILE* fp, long fileSize);
+void parseMach64(FILE* fp, long fileSize);

--- a/source/fileformat/mach-ostructs.c
+++ b/source/fileformat/mach-ostructs.c
@@ -1,0 +1,56 @@
+#include "mach-ostructs.h"
+
+void printMachHeader(mach_header header)
+{
+    printf("\t     magic\t= 0x%X\n \
+            cputype\t= 0x%X\n \
+            cpusubtype\t= 0x%X\n \
+            filetype\t= 0x%X\n \
+            ncmds\t= 0x%X\n \
+            sizzeofcmds= 0x%X\n \
+            flags\t= 0x%X\n", header.magic,
+            header.cputype, header.cpusubtype,
+            header.filetype, header.ncmds, header.sizeofcmds,
+            header.flags);
+}
+
+void printSegmentCommand(segment_command segment)
+{
+    printf("\t     cmd\t= 0x%X\n \
+            cmdsize\t= 0x%X\n \
+            segname\t= %s\n \
+            vmaddr\t= 0x%X\n \
+            vmsize\t= 0x%X\n \
+            fileoff\t= 0x%X\n \
+            filesize\t= 0x%X\n \
+            maxprot\t= 0x%X\n \
+            initprot\t= 0x%X\n \
+            nsects\t= 0x%X\n \
+            flags\t= 0x%X\n", segment.cmd,
+            segment.cmdsize, segment.segname,
+            segment.vmaddr, segment.vmsize, segment.fileoff,
+            segment.filesize, segment.maxprot, segment.initprot,
+            segment.nsects, segment.flags);
+
+
+}
+
+void printSection(section sect)
+{
+    printf("\t     sectname\t= %s\n \
+            segname\t= %s\n \
+            addr\t= 0x%X\n \
+            size\t= 0x%X\n \
+            offset\t= 0x%X\n \
+            align\t= 0x%X\n \
+            reloff\t= 0x%X\n \
+            nreloc\t= 0x%X\n \
+            flags\t= 0x%X\n \
+            reserved1\t= 0x%X\n \
+            reserved2\t= 0x%X\n", sect.sectname,
+            sect.segname, sect.addr,
+            sect.size, sect.offset, sect.align,
+            sect.reloff, sect.nreloc, sect.flags,
+            sect.reserved1, sect.reserved2);
+
+}

--- a/source/fileformat/mach-ostructs.c
+++ b/source/fileformat/mach-ostructs.c
@@ -7,11 +7,26 @@ void printMachHeader(mach_header header)
             cpusubtype\t= 0x%X\n \
             filetype\t= 0x%X\n \
             ncmds\t= 0x%X\n \
-            sizzeofcmds= 0x%X\n \
+            sizeofcmds= 0x%X\n \
             flags\t= 0x%X\n", header.magic,
             header.cputype, header.cpusubtype,
             header.filetype, header.ncmds, header.sizeofcmds,
             header.flags);
+}
+
+void printMachHeader64(mach_header_64 header)
+{
+    printf("\t     magic\t= 0x%X\n \
+            cputype\t= 0x%X\n \
+            cpusubtype\t= 0x%X\n \
+            filetype\t= 0x%X\n \
+            ncmds\t= 0x%X\n \
+            sizeofcmds= 0x%X\n \
+            flags\t= 0x%X\n \
+            reserved\t= 0x%X\n", header.magic,
+            header.cputype, header.cpusubtype,
+            header.filetype, header.ncmds, header.sizeofcmds,
+            header.flags, header.reserved);
 }
 
 void printSegmentCommand(segment_command segment)
@@ -31,8 +46,25 @@ void printSegmentCommand(segment_command segment)
             segment.vmaddr, segment.vmsize, segment.fileoff,
             segment.filesize, segment.maxprot, segment.initprot,
             segment.nsects, segment.flags);
+}
 
-
+void printSegmentCommand64(segment_command_64 segment)
+{
+    printf("\t     cmd\t= 0x%X\n \
+            cmdsize\t= 0x%X\n \
+            segname\t= %s\n \
+            vmaddr\t= 0x%lX\n \
+            vmsize\t= 0x%lX\n \
+            fileoff\t= 0x%lX\n \
+            filesize\t= 0x%lX\n \
+            maxprot\t= 0x%X\n \
+            initprot\t= 0x%X\n \
+            nsects\t= 0x%X\n \
+            flags\t= 0x%X\n", segment.cmd,
+            segment.cmdsize, segment.segname,
+            segment.vmaddr, segment.vmsize, segment.fileoff,
+            segment.filesize, segment.maxprot, segment.initprot,
+            segment.nsects, segment.flags);
 }
 
 void printSection(section sect)
@@ -52,5 +84,23 @@ void printSection(section sect)
             sect.size, sect.offset, sect.align,
             sect.reloff, sect.nreloc, sect.flags,
             sect.reserved1, sect.reserved2);
+}
 
+void printSection64(section_64 sect)
+{
+    printf("\t     sectname\t= %s\n \
+            segname\t= %s\n \
+            addr\t= 0x%lX\n \
+            size\t= 0x%lX\n \
+            offset\t= 0x%X\n \
+            align\t= 0x%X\n \
+            reloff\t= 0x%X\n \
+            nreloc\t= 0x%X\n \
+            flags\t= 0x%X\n \
+            reserved1\t= 0x%X\n \
+            reserved2\t= 0x%X\n", sect.sectname,
+            sect.segname, sect.addr,
+            sect.size, sect.offset, sect.align,
+            sect.reloff, sect.nreloc, sect.flags,
+            sect.reserved1, sect.reserved2);
 }

--- a/source/fileformat/mach-ostructs.h
+++ b/source/fileformat/mach-ostructs.h
@@ -1,0 +1,60 @@
+// Initial reference:
+// http://tfpwn.com/blog/mach-o-file-format.html
+
+#include <string.h>
+#include <stdint.h>
+
+struct fat_header {
+    uint32_t magic;
+    uint32_t nfat_arch;
+};
+
+struct mach_header {
+    uint32_t magic;
+    uint32_t cputype;    // typedef as int in mach/machine.h
+    uint32_t cpusubtype; // typedef as int in mach/machine.h
+    uint32_t filetype;
+    uint32_t ncmds;
+    uint32_t sizeofcmds;
+    uint32_t flags;
+};
+
+struct mach_header_64 {
+
+
+
+};
+
+struct load_command {
+    uint32_t cmd;
+    uint32_t cmdsize;
+};
+struct segment_command {
+    uint32_t cmd;
+    uint32_t cmdsize;
+    char     segname[16];
+    uint32_t vmaddr;
+    uint32_t vmsize;
+    uint32_t fileoff;
+    uint32_t filesize;
+    uint32_t maxprot;
+    uint32_t initprot;
+    uint32_t nsects;
+    uint32_t flags;
+};
+struct section {
+    char        sectname[16];
+    char        segname[16];
+    uint32_t    addr;
+    uint32_t    size;
+    uint32_t    offset;
+    uint32_t    align;
+    uint32_t    reloff;
+    uint32_t    nreloc;
+    uint32_t    flags;
+    uint32_t    reserved1;
+    uint32_t    reserved2;
+};
+
+void printMachHeader32(struct mach_header header);
+void printMachHeader64(struct mach_header_64 header);

--- a/source/fileformat/mach-ostructs.h
+++ b/source/fileformat/mach-ostructs.h
@@ -2,47 +2,62 @@
 // http://tfpwn.com/blog/mach-o-file-format.html
 
 #include <string.h>
+#include <stdio.h>
 #include <stdint.h>
 
-struct fat_header {
-    uint32_t magic;
-    uint32_t nfat_arch;
-};
+/*
+ * shorthand of <mach/vm_prot.h>, <mach/machine.h>
+ */
+typedef uint32_t	cpu_type_t;
+typedef uint32_t	cpu_subtype_t;
+typedef uint32_t	vm_prot_t;
 
-struct mach_header {
-    uint32_t magic;
-    uint32_t cputype;    // typedef as int in mach/machine.h
-    uint32_t cpusubtype; // typedef as int in mach/machine.h
-    uint32_t filetype;
-    uint32_t ncmds;
-    uint32_t sizeofcmds;
-    uint32_t flags;
-};
+// struct fat_header {
+//     uint32_t magic;
+//     uint32_t nfat_arch;
+// };
 
-struct mach_header_64 {
+typedef struct mach_header {
+    uint32_t      magic;
+    cpu_type_t    cputype;    // cpu specifier
+    cpu_subtype_t cpusubtype; // machine specifier
+    uint32_t      filetype;
+    uint32_t      ncmds;
+    uint32_t      sizeofcmds;
+    uint32_t      flags;
+} mach_header;
 
+typedef struct mach_header_64 {
+  	uint32_t	    magic;
+  	cpu_type_t	  cputype;
+  	cpu_subtype_t	cpusubtype;
+  	uint32_t	    filetype;
+  	uint32_t	    ncmds;
+  	uint32_t	    sizeofcmds;
+  	uint32_t	    flags;
+  	uint32_t	    reserved;
+} mach_header_64;
 
+typedef struct segment_command {
+    uint32_t      cmd;
+    uint32_t      cmdsize;
+    char          segname[16];
+    uint32_t      vmaddr;
+    uint32_t      vmsize;
+    uint32_t      fileoff;
+    uint32_t      filesize;
+    uint32_t      maxprot;    // vm_prot_t
+    uint32_t      initprot;   // vm_prot_t
+    uint32_t      nsects;
+    uint32_t      flags;
+} segment_command;
 
-};
-
-struct load_command {
+typedef struct load_command {
     uint32_t cmd;
     uint32_t cmdsize;
-};
-struct segment_command {
-    uint32_t cmd;
-    uint32_t cmdsize;
-    char     segname[16];
-    uint32_t vmaddr;
-    uint32_t vmsize;
-    uint32_t fileoff;
-    uint32_t filesize;
-    uint32_t maxprot;
-    uint32_t initprot;
-    uint32_t nsects;
-    uint32_t flags;
-};
-struct section {
+} load_command;
+
+typedef struct section {
     char        sectname[16];
     char        segname[16];
     uint32_t    addr;
@@ -54,7 +69,9 @@ struct section {
     uint32_t    flags;
     uint32_t    reserved1;
     uint32_t    reserved2;
-};
+} section;
 
-void printMachHeader32(struct mach_header header);
-void printMachHeader64(struct mach_header_64 header);
+void printMachHeader(mach_header header);
+void printMachHeader64(mach_header_64 header);
+void printSegmentCommand(segment_command segment);
+void printSection(section sect);

--- a/source/fileformat/mach-ostructs.h
+++ b/source/fileformat/mach-ostructs.h
@@ -52,10 +52,24 @@ typedef struct segment_command {
     uint32_t      flags;
 } segment_command;
 
-typedef struct load_command {
-    uint32_t cmd;
-    uint32_t cmdsize;
-} load_command;
+typedef struct segment_command_64 {
+    uint32_t      cmd;
+    uint32_t      cmdsize;
+    char          segname[16];
+    uint64_t      vmaddr;
+    uint64_t      vmsize;
+    uint64_t      fileoff;
+    uint64_t      filesize;
+    uint32_t      maxprot;    // vm_prot_t
+    uint32_t      initprot;   // vm_prot_t
+    uint32_t      nsects;
+    uint32_t      flags;
+} segment_command_64;
+
+// typedef struct load_command {
+//     uint32_t cmd;
+//     uint32_t cmdsize;
+// } load_command;
 
 typedef struct section {
     char        sectname[16];
@@ -71,7 +85,23 @@ typedef struct section {
     uint32_t    reserved2;
 } section;
 
+typedef struct section_64 {
+    char        sectname[16];
+    char        segname[16];
+    uint64_t    addr;
+    uint64_t    size;
+    uint32_t    offset;
+    uint32_t    align;
+    uint32_t    reloff;
+    uint32_t    nreloc;
+    uint32_t    flags;
+    uint32_t    reserved1;
+    uint32_t    reserved2;
+} section_64;
+
 void printMachHeader(mach_header header);
 void printMachHeader64(mach_header_64 header);
 void printSegmentCommand(segment_command segment);
+void printSegmentCommand64(segment_command_64 segment);
 void printSection(section sect);
+void printSection64(section_64 sect);

--- a/source/main.c
+++ b/source/main.c
@@ -11,6 +11,7 @@
 #include <string.h>
 #include "fileformat/pe.h"
 #include "fileformat/elf.h"
+#include "fileformat/mach-o.h"
 
 void printHexWithAscii(FILE* fp, long fileSize, unsigned int width);
 void parse(FILE* fp, long fileSize);
@@ -101,6 +102,23 @@ void parse(FILE* fp, long fileSize) {
         free(buffer);
         printf("ELF header detected, decompiling ELF program.\n");
         parseElf(fp, fileSize);
+
+    } else if (*(uint32_t*)&buffer[0] == 0xFEEDFACE ||
+               *(uint32_t*)&buffer[0] == 0xCEFAEDFE) {
+        if (fseek(fp, 0l, SEEK_SET) != 0) {
+            printf("Error seeking back to zero (parse).\n");
+        }
+        free(buffer);
+        printf("32-bit MACH-O header detected, decompiling MACH-O program.\n");
+        parseMach32(fp, fileSize);
+    } else if (*(uint32_t*)&buffer[0] == 0xFEEDFACF ||
+               *(uint32_t*)&buffer[0] == 0xCFFAEDFE) {
+        if (fseek(fp, 0l, SEEK_SET) != 0) {
+            printf("Error seeking back to zero (parse).\n");
+        }
+        free(buffer);
+        printf("64-bit MACH-O header detected, decompiling MACH-O program.\n");
+        parseMach64(fp, fileSize);
     } else {
         free(buffer);
         printf("Could not detect type of executable. Is this binary?\n");


### PR DESCRIPTION
The general parsing of the mach-o format and full code section disassembly are functional for both 32-bit and 64-bit mach-o formats (that being said, I do not have an x86_64 disassembler at this time to fully confirm with). Further analysis with the __LINKEDIT segment and linkage with libraries will be dealt with after finishing the x86 disassembler when working on static analysis.